### PR TITLE
FEATURE: AN-17500 - upgrade shipmonk/phpstan-rules to v3.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "squizlabs/php_codesniffer": "^3",
         "phpcsstandards/phpcsextra": "^1.0",
         "thecodingmachine/phpstan-strict-rules": "^1.0",
-        "shipmonk/phpstan-rules": "^2.3",
+        "shipmonk/phpstan-rules": "^3.2",
         "moxio/php-codesniffer-sniffs": "^2.6"
     },
     "config": {

--- a/phpstan.extension.neon
+++ b/phpstan.extension.neon
@@ -36,8 +36,6 @@ parameters:
     forbidIdenticalClassComparison:
         allowList: []
     shipmonkRules:
-        allowNamedArgumentOnlyInAttributes:
-            enabled: false
         forbidFetchOnMixed:
             enabled: false # Too many false positive
         forbidIdenticalClassComparison:


### PR DESCRIPTION
allowNamedArgumentOnlyInAttributes: removed as it was highly opinionated and did not provide any extra strictness (https://github.com/shipmonk-rnd/phpstan-rules/pull/238)