### PR TITLE
Add PHP 8.4 support and require PHP 8.3+

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.3']
+        php-versions: ['8.3', '8.4']
         dependency-versions: ['lowest', 'highest']
     runs-on: ubuntu-latest
     steps:

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require": {
         "php": "^8.3",
-        "ekino/phpstan-banned-code": "^1.0",
+        "ekino/phpstan-banned-code": "^3.0",
         "ergebnis/phpstan-rules": "^2.5",
         "moxio/php-codesniffer-sniffs": "^2.6",
         "phpcsstandards/phpcsextra": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     },
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "ekino/phpstan-banned-code": "^1.0",
         "ergebnis/phpstan-rules": "^2.5",
         "moxio/php-codesniffer-sniffs": "^2.6",


### PR DESCRIPTION
## Summary
- Update minimum PHP requirement to 8.3
- Add PHP 8.4 to CI test matrix

## Changes
- Update composer.json to require PHP ^8.3
- Update GitHub Actions workflow to test on PHP 8.3 and 8.4

## Related
Part of organization-wide upgrade to standardize on PHP 8.3+ across all packages.

## Test plan
- [ ] CI tests pass on PHP 8.3
- [ ] CI tests pass on PHP 8.4